### PR TITLE
Updates package.json to have the repository field

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.1",
   "description": "gulp coffee react transform",
   "main": "index.js",
+  "repository": "https://github.com/ddiachkov/gulp-coffee-react-transform",
   "scripts": {
     "test": "mocha"
   },


### PR DESCRIPTION
This is relevant because if absent `npm install` warns about it every time I run it.
